### PR TITLE
Companion Watch App

### DIFF
--- a/JotDownInternal.xcodeproj/project.pbxproj
+++ b/JotDownInternal.xcodeproj/project.pbxproj
@@ -6,11 +6,47 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		91DDEB652E86F1DF00984A6B /* JotDownWatch Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 91DDEB5B2E86F1DD00984A6B /* JotDownWatch Watch App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		91DDEB6C2E86F27900984A6B /* WatchConnectivity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 91DDEB6B2E86F27900984A6B /* WatchConnectivity.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		91DDEB632E86F1DF00984A6B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EF18BB872E688D4E00037885 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 91DDEB5A2E86F1DD00984A6B;
+			remoteInfo = "JotDownWatch Watch App";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		91DDEB662E86F1DF00984A6B /* Embed Watch Content */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(CONTENTS_FOLDER_PATH)/Watch";
+			dstSubfolderSpec = 16;
+			files = (
+				91DDEB652E86F1DF00984A6B /* JotDownWatch Watch App.app in Embed Watch Content */,
+			);
+			name = "Embed Watch Content";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
+		91DDEB5B2E86F1DD00984A6B /* JotDownWatch Watch App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "JotDownWatch Watch App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		91DDEB6B2E86F27900984A6B /* WatchConnectivity.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WatchConnectivity.framework; path = System/Library/Frameworks/WatchConnectivity.framework; sourceTree = SDKROOT; };
 		EF18BB8F2E688D4E00037885 /* JotDownInternal.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JotDownInternal.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		91DDEB5C2E86F1DD00984A6B /* JotDownWatch Watch App */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "JotDownWatch Watch App";
+			sourceTree = "<group>";
+		};
 		EF18BB912E688D4E00037885 /* JotDownInternal */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = JotDownInternal;
@@ -19,20 +55,38 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		EF18BB8C2E688D4E00037885 /* Frameworks */ = {
+		91DDEB582E86F1DD00984A6B /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		EF18BB8C2E688D4E00037885 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				91DDEB6C2E86F27900984A6B /* WatchConnectivity.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		91DDEB6A2E86F27800984A6B /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				91DDEB6B2E86F27900984A6B /* WatchConnectivity.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		EF18BB862E688D4E00037885 = {
 			isa = PBXGroup;
 			children = (
 				EF18BB912E688D4E00037885 /* JotDownInternal */,
+				91DDEB5C2E86F1DD00984A6B /* JotDownWatch Watch App */,
+				91DDEB6A2E86F27800984A6B /* Frameworks */,
 				EF18BB902E688D4E00037885 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -41,6 +95,7 @@
 			isa = PBXGroup;
 			children = (
 				EF18BB8F2E688D4E00037885 /* JotDownInternal.app */,
+				91DDEB5B2E86F1DD00984A6B /* JotDownWatch Watch App.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -48,6 +103,28 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		91DDEB5A2E86F1DD00984A6B /* JotDownWatch Watch App */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 91DDEB692E86F1DF00984A6B /* Build configuration list for PBXNativeTarget "JotDownWatch Watch App" */;
+			buildPhases = (
+				91DDEB572E86F1DD00984A6B /* Sources */,
+				91DDEB582E86F1DD00984A6B /* Frameworks */,
+				91DDEB592E86F1DD00984A6B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				91DDEB5C2E86F1DD00984A6B /* JotDownWatch Watch App */,
+			);
+			name = "JotDownWatch Watch App";
+			packageProductDependencies = (
+			);
+			productName = "JotDownWatch Watch App";
+			productReference = 91DDEB5B2E86F1DD00984A6B /* JotDownWatch Watch App.app */;
+			productType = "com.apple.product-type.application";
+		};
 		EF18BB8E2E688D4E00037885 /* JotDownInternal */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = EF18BB9A2E688D5000037885 /* Build configuration list for PBXNativeTarget "JotDownInternal" */;
@@ -55,10 +132,12 @@
 				EF18BB8B2E688D4E00037885 /* Sources */,
 				EF18BB8C2E688D4E00037885 /* Frameworks */,
 				EF18BB8D2E688D4E00037885 /* Resources */,
+				91DDEB662E86F1DF00984A6B /* Embed Watch Content */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				91DDEB642E86F1DF00984A6B /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				EF18BB912E688D4E00037885 /* JotDownInternal */,
@@ -80,6 +159,9 @@
 				LastSwiftUpdateCheck = 2600;
 				LastUpgradeCheck = 2600;
 				TargetAttributes = {
+					91DDEB5A2E86F1DD00984A6B = {
+						CreatedOnToolsVersion = 26.0.1;
+					};
 					EF18BB8E2E688D4E00037885 = {
 						CreatedOnToolsVersion = 26.0;
 					};
@@ -100,11 +182,19 @@
 			projectRoot = "";
 			targets = (
 				EF18BB8E2E688D4E00037885 /* JotDownInternal */,
+				91DDEB5A2E86F1DD00984A6B /* JotDownWatch Watch App */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		91DDEB592E86F1DD00984A6B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		EF18BB8D2E688D4E00037885 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -115,6 +205,13 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		91DDEB572E86F1DD00984A6B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		EF18BB8B2E688D4E00037885 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -124,7 +221,81 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		91DDEB642E86F1DF00984A6B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 91DDEB5A2E86F1DD00984A6B /* JotDownWatch Watch App */;
+			targetProxy = 91DDEB632E86F1DF00984A6B /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
+		91DDEB672E86F1DF00984A6B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = D46454C83G;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = JotDownWatch;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = sankaet.JotDownInternal;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = sankaet.JotDownInternal.watchkitapp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 26.0;
+			};
+			name = Debug;
+		};
+		91DDEB682E86F1DF00984A6B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = D46454C83G;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = JotDownWatch;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = sankaet.JotDownInternal;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = sankaet.JotDownInternal.watchkitapp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 26.0;
+			};
+			name = Release;
+		};
 		EF18BB982E688D5000037885 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -313,6 +484,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		91DDEB692E86F1DF00984A6B /* Build configuration list for PBXNativeTarget "JotDownWatch Watch App" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				91DDEB672E86F1DF00984A6B /* Debug */,
+				91DDEB682E86F1DF00984A6B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		EF18BB8A2E688D4E00037885 /* Build configuration list for PBXProject "JotDownInternal" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/JotDownInternal.xcodeproj/xcshareddata/xcschemes/JotDownInternal 1.xcscheme
+++ b/JotDownInternal.xcodeproj/xcshareddata/xcschemes/JotDownInternal 1.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EF18BB8E2E688D4E00037885"
+               BuildableName = "JotDownInternal.app"
+               BlueprintName = "JotDownInternal"
+               ReferencedContainer = "container:JotDownInternal.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EF18BB8E2E688D4E00037885"
+            BuildableName = "JotDownInternal.app"
+            BlueprintName = "JotDownInternal"
+            ReferencedContainer = "container:JotDownInternal.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EF18BB8E2E688D4E00037885"
+            BuildableName = "JotDownInternal.app"
+            BlueprintName = "JotDownInternal"
+            ReferencedContainer = "container:JotDownInternal.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/JotDownInternal.xcodeproj/xcshareddata/xcschemes/JotDownInternal.xcscheme
+++ b/JotDownInternal.xcodeproj/xcshareddata/xcschemes/JotDownInternal.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EF18BB8E2E688D4E00037885"
+               BuildableName = "JotDownInternal.app"
+               BlueprintName = "JotDownInternal"
+               ReferencedContainer = "container:JotDownInternal.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EF18BB8E2E688D4E00037885"
+            BuildableName = "JotDownInternal.app"
+            BlueprintName = "JotDownInternal"
+            ReferencedContainer = "container:JotDownInternal.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EF18BB8E2E688D4E00037885"
+            BuildableName = "JotDownInternal.app"
+            BlueprintName = "JotDownInternal"
+            ReferencedContainer = "container:JotDownInternal.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/JotDownInternal.xcodeproj/xcshareddata/xcschemes/JotDownWatch Watch App.xcscheme
+++ b/JotDownInternal.xcodeproj/xcshareddata/xcschemes/JotDownWatch Watch App.xcscheme
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "91DDEB5A2E86F1DD00984A6B"
+               BuildableName = "JotDownWatch Watch App.app"
+               BlueprintName = "JotDownWatch Watch App"
+               ReferencedContainer = "container:JotDownInternal.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EF18BB8E2E688D4E00037885"
+               BuildableName = "JotDownInternal.app"
+               BlueprintName = "JotDownInternal"
+               ReferencedContainer = "container:JotDownInternal.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "91DDEB5A2E86F1DD00984A6B"
+            BuildableName = "JotDownWatch Watch App.app"
+            BlueprintName = "JotDownWatch Watch App"
+            ReferencedContainer = "container:JotDownInternal.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "91DDEB5A2E86F1DD00984A6B"
+            BuildableName = "JotDownWatch Watch App.app"
+            BlueprintName = "JotDownWatch Watch App"
+            ReferencedContainer = "container:JotDownInternal.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/JotDownInternal/ContentView.swift
+++ b/JotDownInternal/ContentView.swift
@@ -34,6 +34,9 @@ struct ContentView: View {
 
                     Text(thought.text)
                 }
+            }.onAppear {
+                WatchSessionManager.shared.setup(context: modelContext)
+                
             }
             .navigationTitle("Thoughts")
             .toolbar {

--- a/JotDownInternal/ContentView.swift
+++ b/JotDownInternal/ContentView.swift
@@ -36,7 +36,6 @@ struct ContentView: View {
                 }
             }.onAppear {
                 WatchSessionManager.shared.setup(context: modelContext)
-                
             }
             .navigationTitle("Thoughts")
             .toolbar {

--- a/JotDownInternal/WatchCommunicationManager.swift
+++ b/JotDownInternal/WatchCommunicationManager.swift
@@ -3,8 +3,6 @@ import SwiftData
 import SwiftUI
 
 class WatchSessionManager: NSObject, WCSessionDelegate {
-    
-
     static let shared = WatchSessionManager()
     var modelContext: ModelContext?
 
@@ -20,6 +18,7 @@ class WatchSessionManager: NSObject, WCSessionDelegate {
 
     func session(_ session: WCSession, didReceiveMessage message: [String : Any], replyHandler: @escaping ([String : Any]) -> Void) {
         if let text = message["thought"] as? String, !text.isEmpty {
+            print("Received thought: \(text)")
             Task { @MainActor in
                 let thought = Thought(text: text)
                 modelContext?.insert(thought)

--- a/JotDownInternal/WatchCommunicationManager.swift
+++ b/JotDownInternal/WatchCommunicationManager.swift
@@ -1,0 +1,50 @@
+import WatchConnectivity
+import SwiftData
+import SwiftUI
+
+class WatchSessionManager: NSObject, WCSessionDelegate {
+    
+
+    static let shared = WatchSessionManager()
+    var modelContext: ModelContext?
+
+    func setup(context: ModelContext) {
+        self.modelContext = context
+        if WCSession.isSupported() {
+            let session = WCSession.default
+            session.delegate = self
+            session.activate()
+            print("WCSession activated")
+        }
+    }
+
+    func session(_ session: WCSession, didReceiveMessage message: [String : Any], replyHandler: @escaping ([String : Any]) -> Void) {
+        if let text = message["thought"] as? String, !text.isEmpty {
+            Task { @MainActor in
+                let thought = Thought(text: text)
+                modelContext?.insert(thought)
+                try? modelContext?.save()
+            }
+            replyHandler([:]) // Optionally acknowledge
+            return
+        }
+
+        if message["request"] as? String == "thoughts" {
+            let thoughts = fetchThoughts()
+            replyHandler(["thoughts": thoughts])
+            return
+        }
+    }
+
+    func fetchThoughts() -> [String] {
+        guard let context = modelContext else { return [] }
+        let descriptor = FetchDescriptor<Thought>()
+        let results = (try? context.fetch(descriptor)) ?? []
+        return results.map { $0.text }
+    }
+
+    // Required delegate stubs
+    func sessionDidBecomeInactive(_ session: WCSession) {}
+    func sessionDidDeactivate(_ session: WCSession) {}
+    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {}
+}

--- a/JotDownWatch Watch App/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/JotDownWatch Watch App/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/JotDownWatch Watch App/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/JotDownWatch Watch App/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "watchos",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/JotDownWatch Watch App/Assets.xcassets/Contents.json
+++ b/JotDownWatch Watch App/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/JotDownWatch Watch App/ContentView.swift
+++ b/JotDownWatch Watch App/ContentView.swift
@@ -7,15 +7,52 @@
 
 import SwiftUI
 
+
 struct ContentView: View {
+    @State private var showingInput = false
+    @State private var thoughtInput = ""
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        TabView {
+            VStack {
+                Spacer()
+                Button(action: {
+                    showingInput = true
+                }) {
+                    Image(systemName: "plus.circle.fill")
+                        .resizable()
+                        .frame(width: 80, height: 80)
+                        .foregroundColor(.accentColor)
+                }
+                .buttonStyle(.plain)
+                .sheet(isPresented: $showingInput) {
+                    VStack {
+                        Text("New Thought")
+                            .font(.headline)
+                        TextField("Enter your thought", text: $thoughtInput)
+                            .padding()
+                        Button("Save") {
+                            // TODO save to swift data
+                        }
+                        .buttonStyle(.borderedProminent)
+                        Spacer()
+                    }
+                    .padding()
+                }
+                Spacer()
+            }
+            .tag(0)
+
+            List {
+                // TODO fetch from swift data
+                // ForEach(thoughts, id: \ .self) { thought in
+                //     Text(thought)
+                //         .font(.body)
+                // }
+             }
+            .tag(1)
         }
-        .padding()
+        .tabViewStyle(.page)
     }
 }
 

--- a/JotDownWatch Watch App/ContentView.swift
+++ b/JotDownWatch Watch App/ContentView.swift
@@ -8,12 +8,11 @@
 import SwiftUI
 import WatchConnectivity
 
-
 struct ContentView: View {
     @State private var showingInput = false
     @State private var thoughtInput = ""
-    @ObservedObject  var watchSessionManager = WatchSessionManager.shared
-    
+    @ObservedObject var watchSessionManager = WatchSessionManager.shared
+
     var body: some View {
         TabView {
             VStack {
@@ -36,8 +35,9 @@ struct ContentView: View {
                         Button("Save") {
                             let message = ["thought": thoughtInput]
                             if WCSession.default.isReachable {
-                                WCSession.default.sendMessage(message, replyHandler: { _ in}, errorHandler: { error in
-                           
+                                WCSession.default.sendMessage(message, replyHandler: { _ in
+                                    watchSessionManager.requestThoughts()
+                                }, errorHandler: { error in
                                     print("Error sending message: \(error.localizedDescription)")
                                 })
                                 thoughtInput = ""
@@ -65,16 +65,15 @@ struct ContentView: View {
                 }
              }
             .tag(1)
-            // .onAppear {
-            //     watchSessionManager.requestThoughts()
-            // }
+            .onAppear {
+                watchSessionManager.requestThoughts()
+            }
         }
         .tabViewStyle(.page)
         .onAppear {
             if WCSession.isSupported() {
                 WCSession.default.delegate = WatchSessionManager.shared
                 WCSession.default.activate()
-                watchSessionManager.requestThoughts()
             }
         }
     }

--- a/JotDownWatch Watch App/ContentView.swift
+++ b/JotDownWatch Watch App/ContentView.swift
@@ -36,7 +36,8 @@ struct ContentView: View {
                         Button("Save") {
                             let message = ["thought": thoughtInput]
                             if WCSession.default.isReachable {
-                                WCSession.default.sendMessage(message, replyHandler: nil, errorHandler: { error in
+                                WCSession.default.sendMessage(message, replyHandler: { _ in}, errorHandler: { error in
+                           
                                     print("Error sending message: \(error.localizedDescription)")
                                 })
                                 thoughtInput = ""

--- a/JotDownWatch Watch App/ContentView.swift
+++ b/JotDownWatch Watch App/ContentView.swift
@@ -1,0 +1,24 @@
+//
+//  ContentView.swift
+//  JotDownWatch Watch App
+//
+//  Created by Joseph Masson on 9/26/25.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                .foregroundStyle(.tint)
+            Text("Hello, world!")
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/JotDownWatch Watch App/JotDownWatchApp.swift
+++ b/JotDownWatch Watch App/JotDownWatchApp.swift
@@ -1,0 +1,17 @@
+//
+//  JotDownWatchApp.swift
+//  JotDownWatch Watch App
+//
+//  Created by Joseph Masson on 9/26/25.
+//
+
+import SwiftUI
+
+@main
+struct JotDownWatch_Watch_AppApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/JotDownWatch Watch App/JotDownWatchApp.swift
+++ b/JotDownWatch Watch App/JotDownWatchApp.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 @main
-struct JotDownWatch_Watch_AppApp: App {
+struct JotDownWatchApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()

--- a/JotDownWatch Watch App/WatchSessionManager.swift
+++ b/JotDownWatch Watch App/WatchSessionManager.swift
@@ -1,5 +1,5 @@
 //
-//  CommunicationManager.swift
+//  WatchSessionManager.swift
 //  JotDownInternal
 //
 //  Created by Joseph Masson on 9/26/25.
@@ -40,15 +40,12 @@ class WatchSessionManager: NSObject, ObservableObject, WCSessionDelegate {
         }
     }
 
-    // WCSessionDelegate stubs
     func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
-        // You can add logging or error handling here
+        if activationState == .activated {
+            requestThoughts()
+        }
     }
 
-    func session(_ session: WCSession, didReceiveMessage message: [String : Any]) {
-        // Handle incoming messages if needed
-    }
-
-//    func sessionDidBecomeInactive(_ session: WCSession) {}
-//    func sessionDidDeactivate(_ session: WCSession) {}
+    // Required stub
+    func session(_ session:WCSession, didReceiveMessage message: [String: Any]) {}
 }

--- a/JotDownWatch Watch App/WatchSessionManager.swift
+++ b/JotDownWatch Watch App/WatchSessionManager.swift
@@ -1,0 +1,54 @@
+//
+//  CommunicationManager.swift
+//  JotDownInternal
+//
+//  Created by Joseph Masson on 9/26/25.
+//
+
+import Foundation
+import WatchConnectivity
+import Combine
+
+class WatchSessionManager: NSObject, ObservableObject, WCSessionDelegate {
+    static let shared = WatchSessionManager()
+    @Published var thoughts: [String] = []
+
+    override init() {
+        super.init()
+        activateSession()
+    }
+
+    private func activateSession() {
+        if WCSession.isSupported() {
+            let session = WCSession.default
+            session.delegate = self
+            session.activate()
+        }
+    }
+
+    func requestThoughts() {
+        if WCSession.default.isReachable {
+            WCSession.default.sendMessage(["request": "thoughts"], replyHandler: { response in
+                if let receivedThoughts = response["thoughts"] as? [String] {
+                    DispatchQueue.main.async {
+                        self.thoughts = receivedThoughts
+                    }
+                }
+            }, errorHandler: { error in
+                print("Error requesting thoughts: \(error.localizedDescription)")
+            })
+        }
+    }
+
+    // WCSessionDelegate stubs
+    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
+        // You can add logging or error handling here
+    }
+
+    func session(_ session: WCSession, didReceiveMessage message: [String : Any]) {
+        // Handle incoming messages if needed
+    }
+
+//    func sessionDidBecomeInactive(_ session: WCSession) {}
+//    func sessionDidDeactivate(_ session: WCSession) {}
+}


### PR DESCRIPTION
Watch App can enter a thought and see thoughts. Used WatchConnectivity to pull thoughts from SwiftData and create received thoughts. Should be able to create thoughts/see thoughts on both devices and syncs across updates.

To test on Xcode:
- Open Devices and Simulators menu
- Create new (+) in Simulators
- Create iPhone simulator and select "Paired Apple Watch"
- Create

Build both the Watch and Phone target and they should be lined. 